### PR TITLE
Change CSS pseudoclass selector name from granted to allowed

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -99,7 +99,7 @@ IDL:
 
 A new css selector will be added which applies to PEPC elements and can be used to target css when the user permission is granted:
 
-    :granted
+    :allowed
 
 The PEPC is not allowed to have any child elements or contents.
 


### PR DESCRIPTION
- Change CSS pseudoclass selector name from `:granted` to `:allowed` to use consistent language